### PR TITLE
Remove whitespace at the end of lines which do not include a comment.

### DIFF
--- a/plugin/src/main/kotlin/de/fayard/KotlinPoetry.kt
+++ b/plugin/src/main/kotlin/de/fayard/KotlinPoetry.kt
@@ -101,7 +101,7 @@ fun kotlinpoet(versions: List<Dependency>, gradleConfig: GradleConfig): KotlinPo
 fun Dependency.generateVersionProperty(): PropertySpec {
     return constStringProperty(
         name = versionName,
-        initializer = CodeBlock.of("%S %L", version, versionInformation())
+        initializer = CodeBlock.of("%S%L", version, versionInformation())
     )
 }
 
@@ -109,7 +109,7 @@ fun Dependency.versionInformation(): String {
     val comment = when {
         version == "none" -> "// No version. See buildSrcVersions#23"
         available == null -> ""
-        else -> available.displayComment()
+        else -> " ${available.displayComment()}"
     }
     return if (comment.length + versionName.length + version.length > 70) {
             '\n' + comment


### PR DESCRIPTION
Currently, lines in Libs.kt and Versions.kt which do not have a versioned comment
will have a whitespace added to them at the end because of the way the
string is formatted. This causes extra differences when updating the
file. This PR removes that whitespace.